### PR TITLE
舰上暴击机使用的CSS-class进行修改

### DIFF
--- a/script/equipData.js
+++ b/script/equipData.js
@@ -109,7 +109,7 @@ var kanColle = {
 				'大発動艇' : 'landing-craft',
 				'艦載機' : 'carrier-fighter',
 				'艦上戦闘機' : 'carrier-fighter',
-				'艦上爆撃機' : 'carrier-blasting'
+				'艦上爆撃機' : 'carrier-dive-bomber'
 			},
 
 			searchClass: function(category) {


### PR DESCRIPTION
carrier-blasting修改为carrier-dive-bomber

更加倾向使用军事用语，做出此修改，参考与原版KCV源代码：

> KanColleViewer-4.2.3\source\Grabacr07.KanColleWrapper\Models\SlotItemIconType.cs

里面有较为详细的英文术语
